### PR TITLE
Add in-memory task backend with hot-swappable backend selection

### DIFF
--- a/openspec/changes/in-memory-task-backend/.openspec.yaml
+++ b/openspec/changes/in-memory-task-backend/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-06

--- a/openspec/changes/in-memory-task-backend/design.md
+++ b/openspec/changes/in-memory-task-backend/design.md
@@ -1,0 +1,123 @@
+## Context
+
+The extension currently hardcodes `BeadsBackend` in `extension.ts` activation. The `TaskBackend` interface is already cleanly abstracted — `BeadsBackend` is the only implementation. The agent skills (planning, execution, review) reference `.beads/issues.jsonl` by name and include it in git commits alongside code changes.
+
+The extension has 7 registered language model tools (4 task management, 3 navigation). Adding `misetay_backendInfo` brings it to 8.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users can try the full plan/execute/review workflow without installing Beads CLI
+- Backend selection via VS Code settings (`misetay.taskBackend`)
+- Agent skills adapt commit behavior based on backend capabilities
+- Zero breaking changes for existing Beads users
+
+**Non-Goals:**
+- Persisting in-memory state across sessions (that's what Beads is for)
+- Auto-detecting whether Beads is installed and falling back automatically
+- Supporting other backends (GitHub Issues, Linear) in this change
+- Changing the default backend from Beads
+
+## Decisions
+
+### 1. InMemoryBackend stores tasks in a Map, generates sequential IDs
+
+`InMemoryBackend` holds a `Map<string, Task>` and a counter. Task IDs follow the format `mem-1`, `mem-2`, etc. Dependencies are stored as arrays of ID strings on each task (same as the `Task` interface already defines).
+
+**Why not UUIDs?** Sequential IDs are easier to reference in conversation and match the `bd-xxx` pattern users see with Beads. The `mem-` prefix makes it obvious which backend is active.
+
+**Why not persist to a temp file?** That would add complexity for marginal benefit. The point of in-memory mode is zero-friction trial, not production use.
+
+### 2. VS Code configuration setting in `package.json`
+
+Add a `misetay.taskBackend` setting under `contributes.configuration`:
+
+```json
+{
+  "misetay.taskBackend": {
+    "type": "string",
+    "enum": ["beads", "inMemory"],
+    "default": "beads",
+    "description": "Task backend to use. 'beads' requires Beads CLI installed. 'inMemory' works without any dependencies but tasks are lost when VS Code restarts."
+  }
+}
+```
+
+`extension.ts` reads this at activation and instantiates the appropriate backend. Changing the setting hot-swaps the backend immediately — tools and views use a getter so they always reference the current backend.
+
+**Why not auto-detect Beads?** Explicit configuration is more predictable. Auto-detection adds edge cases (Beads installed but not initialized, Beads on PATH in some terminals but not others). Users should consciously choose.
+
+### 3. `misetay_backendInfo` tool returns backend metadata
+
+A new language model tool registered alongside the existing 7. No input parameters. Returns:
+
+```json
+{
+  "backend": "inMemory",
+  "persistsToFiles": false
+}
+```
+
+or for Beads:
+
+```json
+{
+  "backend": "beads",
+  "persistsToFiles": true
+}
+```
+
+This is implemented by adding a `backendInfo()` method to the `TaskBackend` interface:
+
+```typescript
+interface BackendInfo {
+  name: string;
+  persistsToFiles: boolean;
+}
+
+interface TaskBackend {
+  // ... existing methods ...
+  backendInfo(): BackendInfo;
+}
+```
+
+Each backend returns its own info. The tool handler in `taskTools.ts` just calls `backend.backendInfo()` and returns the result.
+
+**Why a tool instead of embedding info in skill text?** Skills are static markdown files copied to `.github/`. They can't be templated at install time without adding a build step. A tool keeps skills generic and works for any future backend.
+
+**Why not return info from every tool call?** That would change the response schema of existing tools. A dedicated tool is cleaner and only called when the agent needs it.
+
+### 4. Skills use `backendInfo` to conditionally commit state
+
+The three skills are updated with a common pattern. Before any state-commit step, the agent calls `misetay_backendInfo`. If `persistsToFiles` is false, it skips the step.
+
+**Planning skill** — Step 5 ("Commit Planning State"):
+- If `persistsToFiles`: `git add -A && git commit -m "Plan feature: <name>"` (existing behavior)
+- If not: skip the commit entirely, just confirm tasks were created
+
+**Execution skill** — Step 5 ("Commit Changes and State Together"):
+- If `persistsToFiles`: `git add -A` stages both code and `.beads/` state (existing behavior)
+- If not: `git add` only the code files, skip staging `.beads/`
+
+**Review skill** — fix commit steps:
+- Same pattern as execution: only stage code files when `persistsToFiles` is false
+
+The skill text uses conditional language: "Call `misetay_backendInfo`. If `persistsToFiles` is true, stage all changes including task state files. Otherwise, stage only your code changes."
+
+### 5. Information message on activation with in-memory backend
+
+When `misetay.taskBackend` is `"inMemory"`, show an information message on activation:
+
+> "Misetay is using in-memory task storage. Tasks will be lost when VS Code restarts. Install Beads CLI for persistent task tracking."
+
+Shown once per session, not on every activation. Use `vscode.window.showInformationMessage`.
+
+## Risks / Trade-offs
+
+**[Tasks lost on restart] → Acceptable** — This is by design. The info message makes it clear. Users who need persistence install Beads.
+
+**[Agent may forget to call backendInfo] → Low risk** — The skills explicitly instruct the agent to call it. If it forgets, the worst case is an empty "Plan feature" commit (no `.beads/` files to stage) or a harmless `git add -A` that stages nothing extra.
+
+**[Hot-switching loses in-memory tasks] → Acceptable** — Switching from inMemory to beads (or vice versa) discards any tasks in the old backend. This is inherent and the notification message makes it clear.
+
+**[New method on TaskBackend interface] → Minimal risk** — Adding `backendInfo()` to the interface is additive. `BeadsBackend` gets the method too. No existing code breaks.

--- a/openspec/changes/in-memory-task-backend/proposal.md
+++ b/openspec/changes/in-memory-task-backend/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The extension currently requires Beads CLI (`bd`) to be installed before any task management features work. This creates an onboarding cliff — users who discover Misetay can't try the core plan/execute/review workflow without first installing an external dependency. An in-memory task backend lets people experience the full workflow immediately, with zero setup.
+
+## What Changes
+
+- Add a new `InMemoryBackend` class implementing the existing `TaskBackend` interface, storing tasks in extension memory (non-persistent across sessions)
+- Introduce a VS Code configuration setting (`misetay.taskBackend`) to choose between `"beads"` (default) and `"inMemory"` backends
+- Update extension activation to read the setting and instantiate the chosen backend
+- Show an informational message when using in-memory mode, noting that tasks won't persist across sessions
+- Add a new `misetay_backendInfo` language model tool that returns backend metadata (e.g., `{ persistsToFiles: true/false }`). The agent calls this to decide whether to include task state in git commits.
+- Update agent skills (planning, execution, review) to call `misetay_backendInfo` before state-commit steps, and skip committing `.beads/` state when `persistsToFiles` is false. Currently the skills hardcode committing `.beads/issues.jsonl` alongside code changes and committing planning state — these steps are meaningless without a file-backed backend.
+
+## Capabilities
+
+### New Capabilities
+- `in-memory-backend`: In-memory implementation of TaskBackend that requires no external dependencies
+- `backend-settings`: VS Code configuration settings for selecting and configuring the task backend
+
+### Modified Capabilities
+- `state-management`: Backend selection is now configurable; the default backend remains Beads but can be switched via settings. New `misetay_backendInfo` tool exposes backend metadata so the agent can adapt its behavior.
+
+## Impact
+
+- **Code**: New `inMemoryBackend.ts` file; changes to `extension.ts` activation logic to read settings
+- **Settings**: New `misetay.taskBackend` configuration property in `package.json` contributes section
+- **Skills**: Planning, execution, and review skills need conditional logic around state-commit steps (committing `.beads/issues.jsonl`, "Plan feature" commits). The agent needs a way to know which backend is active so it can skip file-based state commits in in-memory mode.
+- **User experience**: Users without Beads installed get a working (but non-persistent) experience out of the box
+- **Existing behavior**: No change for users who already have Beads — it remains the default

--- a/openspec/changes/in-memory-task-backend/specs/backend-settings/spec.md
+++ b/openspec/changes/in-memory-task-backend/specs/backend-settings/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Extension provides a task backend setting
+The extension SHALL contribute a `misetay.taskBackend` configuration setting that allows users to select which task backend to use.
+
+#### Scenario: Setting exists with correct schema
+- **WHEN** user opens VS Code settings and searches for "misetay"
+- **THEN** a `misetay.taskBackend` setting is available with options "beads" and "inMemory"
+
+#### Scenario: Default value
+- **WHEN** user has not configured `misetay.taskBackend`
+- **THEN** the setting defaults to "beads"
+
+### Requirement: Extension instantiates backend from setting
+The extension SHALL read the `misetay.taskBackend` setting at activation and instantiate the corresponding backend.
+
+#### Scenario: Setting is "beads"
+- **WHEN** `misetay.taskBackend` is "beads" and extension activates
+- **THEN** extension instantiates BeadsBackend
+
+#### Scenario: Setting is "inMemory"
+- **WHEN** `misetay.taskBackend` is "inMemory" and extension activates
+- **THEN** extension instantiates InMemoryBackend
+
+### Requirement: In-memory mode shows informational message
+The extension SHALL display an informational message when activating with the in-memory backend, warning that tasks will not persist.
+
+#### Scenario: Activation with in-memory backend
+- **WHEN** extension activates with `misetay.taskBackend` set to "inMemory"
+- **THEN** extension displays an information message stating tasks will be lost on restart
+
+#### Scenario: Activation with beads backend
+- **WHEN** extension activates with `misetay.taskBackend` set to "beads"
+- **THEN** no informational message about task persistence is shown
+
+### Requirement: Setting change takes effect immediately
+Changing the `misetay.taskBackend` setting SHALL hot-swap the active backend without requiring a window reload.
+
+#### Scenario: Changing setting mid-session
+- **WHEN** user changes `misetay.taskBackend` from "beads" to "inMemory"
+- **THEN** the extension instantiates a new InMemoryBackend and all tools and views use it immediately
+
+#### Scenario: Switching notifies user
+- **WHEN** user changes `misetay.taskBackend`
+- **THEN** extension displays an informational message confirming the switch
+
+#### Scenario: Task status view refreshes on switch
+- **WHEN** user changes `misetay.taskBackend` while the task status view is open
+- **THEN** the view refreshes to show tasks from the new backend

--- a/openspec/changes/in-memory-task-backend/specs/in-memory-backend/spec.md
+++ b/openspec/changes/in-memory-task-backend/specs/in-memory-backend/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: In-memory backend implements TaskBackend interface
+The InMemoryBackend class SHALL implement the full TaskBackend interface, storing all task data in extension memory with no external dependencies.
+
+#### Scenario: Creating a task
+- **WHEN** agent calls createTask(title, description, status) on InMemoryBackend
+- **THEN** backend stores the task in memory and returns it with a unique ID
+
+#### Scenario: Task ID format
+- **WHEN** a task is created via InMemoryBackend
+- **THEN** the returned ID follows the format "mem-N" where N is a sequential integer starting at 1
+
+#### Scenario: Updating a task
+- **WHEN** agent calls updateTask(id, updates) on InMemoryBackend
+- **THEN** backend updates the specified fields and returns the updated task
+
+#### Scenario: Updating a nonexistent task
+- **WHEN** agent calls updateTask with an ID that does not exist
+- **THEN** backend throws an error indicating the task was not found
+
+#### Scenario: Listing all tasks
+- **WHEN** agent calls listTasks() on InMemoryBackend with no filters
+- **THEN** backend returns all stored tasks
+
+#### Scenario: Filtering tasks by status
+- **WHEN** agent calls listTasks({status: "ready"}) on InMemoryBackend
+- **THEN** backend returns only tasks with status "ready"
+
+#### Scenario: Adding a dependency
+- **WHEN** agent calls addDependency(childId, parentId) on InMemoryBackend
+- **THEN** backend records the dependency so that childId's dependencies array includes parentId
+
+### Requirement: In-memory backend does not persist across sessions
+Task data in InMemoryBackend SHALL exist only in extension memory and SHALL NOT survive VS Code restarts.
+
+#### Scenario: Restarting VS Code
+- **WHEN** user closes and reopens VS Code while using InMemoryBackend
+- **THEN** all previously created tasks are gone and listTasks returns an empty array
+
+#### Scenario: New chat session within same VS Code session
+- **WHEN** user starts a new chat conversation without restarting VS Code
+- **THEN** tasks created in prior conversations are still available via listTasks
+
+### Requirement: In-memory backend reports its capabilities
+InMemoryBackend SHALL implement backendInfo() returning metadata that identifies it as non-file-persisting.
+
+#### Scenario: Querying backend info
+- **WHEN** backendInfo() is called on InMemoryBackend
+- **THEN** it returns `{ name: "inMemory", persistsToFiles: false }`

--- a/openspec/changes/in-memory-task-backend/specs/state-management/spec.md
+++ b/openspec/changes/in-memory-task-backend/specs/state-management/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Extension registers backendInfo tool
+The extension SHALL register a `misetay_backendInfo` language model tool that returns metadata about the active backend.
+
+#### Scenario: backendInfo tool registration
+- **WHEN** extension activates
+- **THEN** extension registers dshearer.misetay/backendInfo tool
+
+#### Scenario: Calling backendInfo with Beads backend
+- **WHEN** agent calls backendInfo and active backend is BeadsBackend
+- **THEN** tool returns `{ name: "beads", persistsToFiles: true }`
+
+#### Scenario: Calling backendInfo with in-memory backend
+- **WHEN** agent calls backendInfo and active backend is InMemoryBackend
+- **THEN** tool returns `{ name: "inMemory", persistsToFiles: false }`
+
+### Requirement: TaskBackend interface includes backendInfo method
+The TaskBackend interface SHALL include a `backendInfo()` method returning a `BackendInfo` object with `name` and `persistsToFiles` fields.
+
+#### Scenario: BackendInfo return type
+- **WHEN** any backend's backendInfo() is called
+- **THEN** it returns an object with string `name` and boolean `persistsToFiles`
+
+## MODIFIED Requirements
+
+### Requirement: Tools delegate to pluggable backend
+The extension SHALL support multiple task backend implementations through an adapter interface. The active backend is determined by the `misetay.taskBackend` configuration setting.
+
+#### Scenario: Backend adapter interface
+- **WHEN** extension needs to perform task operations
+- **THEN** extension delegates to configured backend adapter
+
+#### Scenario: Default Beads backend
+- **WHEN** `misetay.taskBackend` is not explicitly configured
+- **THEN** extension uses Beads CLI backend adapter
+
+#### Scenario: In-memory backend selected
+- **WHEN** `misetay.taskBackend` is set to "inMemory"
+- **THEN** extension uses InMemoryBackend adapter
+
+### Requirement: State persists across sessions
+Task state persistence SHALL depend on the active backend. File-backed backends (Beads) persist across sessions. In-memory backends do not.
+
+#### Scenario: Restarting VS Code with Beads backend
+- **WHEN** user closes and reopens VS Code while using BeadsBackend
+- **THEN** task state remains unchanged
+
+#### Scenario: Restarting VS Code with in-memory backend
+- **WHEN** user closes and reopens VS Code while using InMemoryBackend
+- **THEN** all task state is lost
+
+#### Scenario: New chat session
+- **WHEN** user starts new chat with agent (without restarting VS Code)
+- **THEN** agent can call listTasks to retrieve tasks regardless of backend

--- a/openspec/changes/in-memory-task-backend/tasks.md
+++ b/openspec/changes/in-memory-task-backend/tasks.md
@@ -1,0 +1,28 @@
+## 1. Interface & Types
+
+- [x] 1.1 Add `BackendInfo` type and `backendInfo()` method to `TaskBackend` interface in `taskBackend.ts`
+- [x] 1.2 Implement `backendInfo()` on `BeadsBackend` returning `{ name: "beads", persistsToFiles: true }`
+
+## 2. In-Memory Backend
+
+- [x] 2.1 Create `src/inMemoryBackend.ts` implementing `TaskBackend` with a `Map<string, Task>` store and sequential `mem-N` IDs
+- [x] 2.2 Implement `createTask`, `updateTask`, `listTasks`, `addDependency` methods
+- [x] 2.3 Implement `backendInfo()` returning `{ name: "inMemory", persistsToFiles: false }`
+- [x] 2.4 Add unit tests for `InMemoryBackend` in `src/test/inMemoryBackend.test.ts`
+
+## 3. Configuration & Activation
+
+- [x] 3.1 Add `misetay.taskBackend` setting to `contributes.configuration` in `package.json` with enum `["beads", "inMemory"]` defaulting to `"beads"`
+- [x] 3.2 Update `extension.ts` activation to read the setting and instantiate the chosen backend
+- [x] 3.3 Show informational message when activating with in-memory backend
+
+## 4. Backend Info Tool
+
+- [x] 4.1 Register `misetay_backendInfo` language model tool in `taskTools.ts` that calls `backend.backendInfo()`
+- [x] 4.2 Add tool definition to `contributes.languageModelTools` in `package.json`
+
+## 5. Skill Updates
+
+- [x] 5.1 Update planning skill to call `misetay_backendInfo` and skip state commit when `persistsToFiles` is false
+- [x] 5.2 Update execution skill to call `misetay_backendInfo` and only stage code files (not `.beads/`) when `persistsToFiles` is false
+- [x] 5.3 Update review skill to call `misetay_backendInfo` and only stage code files when `persistsToFiles` is false

--- a/package.json
+++ b/package.json
@@ -15,6 +15,17 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "configuration": {
+      "title": "Misetay",
+      "properties": {
+        "misetay.taskBackend": {
+          "type": "string",
+          "enum": ["beads", "inMemory"],
+          "default": "beads",
+          "description": "Task backend to use. 'beads' requires Beads CLI installed. 'inMemory' works without any dependencies but tasks are lost when VS Code restarts."
+        }
+      }
+    },
     "commands": [
       {
         "command": "misetay.installAgent",
@@ -220,6 +231,18 @@
           "required": [
             "line"
           ]
+        }
+      },
+      {
+        "name": "misetay_backendInfo",
+        "displayName": "Backend Info",
+        "toolReferenceName": "backendInfo",
+        "modelDescription": "Returns metadata about the active task backend, including its name and whether it persists to files. Call this before commit steps to decide whether to stage task state files.",
+        "userDescription": "Get info about the active task backend",
+        "canBeReferencedInPrompt": true,
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
         }
       }
     ]

--- a/skills/execution/SKILL.md
+++ b/skills/execution/SKILL.md
@@ -72,15 +72,19 @@ Use dshearer.misetay/updateTask:
 - updates: { status: "committed" }
 ```
 
-This updates the `.beads/issues.jsonl` file, marking the task as complete.
+This marks the task as complete in the backend.
 
 ### Step 5: Commit Changes and State Together
 
-Now commit both the code changes AND the Beads state update in one atomic commit:
+Call `dshearer.misetay/backendInfo`. If `persistsToFiles` is true, stage all changes (code + task state files). If `persistsToFiles` is false, stage only your code changes (not `.beads/`).
 
 ```bash
-# Stage all changes (code + .beads/issues.jsonl)
+# If persistsToFiles is true:
 git add -A
+
+# If persistsToFiles is false:
+# Stage only specific code files you changed (not .beads/)
+git add <file1> <file2> ...
 
 # Commit with task ID in message
 git commit -m "Task description (task-id)"
@@ -93,9 +97,8 @@ Examples:
 - `"Update Button component to use theme colors (bd-abc3)"`
 - `"Add user authentication API integration (bd-xyz7)"`
 
-**Critical**: 
+**Critical**:
 - Always update status to "committed" BEFORE running git commit
-- This ensures the commit includes both code changes and state transition
 - Always include the task ID in parentheses at the end
 - This enables finding commits later with `git log --grep="task-id"`
 

--- a/skills/planning/SKILL.md
+++ b/skills/planning/SKILL.md
@@ -100,19 +100,22 @@ Once the user approves, create tasks using the tools:
 
 ### Step 5: Commit Planning State
 
-After creating all tasks, commit the Beads state to Git:
+After creating all tasks, call `dshearer.misetay/backendInfo` to check the backend type.
+
+**If `persistsToFiles` is true:** Commit the task state to Git:
 
 ```bash
-# Commit the task state created during planning
 git add -A
 git commit -m "Plan feature: <feature name>"
 ```
 
-This creates a commit containing only the `.beads/issues.jsonl` changes from planning.
+This creates a commit containing the `.beads/issues.jsonl` changes from planning.
+
+**If `persistsToFiles` is false:** Skip the commit — in-memory tasks have no files to stage. Just confirm that tasks were created successfully.
 
 ### Step 6: Confirm Completion
 
-After committing the plan:
+After creating the plan (and committing if applicable):
 
 1. List the created tasks to confirm they're in the system using `dshearer.misetay/listTasks`
 

--- a/src/beadsBackend.ts
+++ b/src/beadsBackend.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { TaskBackend, Task, TaskStatus } from './taskBackend';
+import { TaskBackend, Task, TaskStatus, BackendInfo } from './taskBackend';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 
@@ -13,6 +13,10 @@ export class BeadsBackend implements TaskBackend {
 
 	constructor(workspaceRoot: string) {
 		this.workspaceRoot = workspaceRoot;
+	}
+
+	backendInfo(): BackendInfo {
+		return { name: 'beads', persistsToFiles: true };
 	}
 
 	/**

--- a/src/inMemoryBackend.ts
+++ b/src/inMemoryBackend.ts
@@ -1,0 +1,52 @@
+import { TaskBackend, Task, TaskStatus, BackendInfo } from './taskBackend';
+
+/**
+ * In-memory task backend that requires no external dependencies.
+ * Tasks are lost when VS Code restarts.
+ */
+export class InMemoryBackend implements TaskBackend {
+	private tasks = new Map<string, Task>();
+	private nextId = 1;
+
+	backendInfo(): BackendInfo {
+		return { name: 'inMemory', persistsToFiles: false };
+	}
+
+	async createTask(title: string, description: string, status: TaskStatus = 'ready'): Promise<Task> {
+		const id = `mem-${this.nextId++}`;
+		const task: Task = { id, title, description, status };
+		this.tasks.set(id, task);
+		return { ...task };
+	}
+
+	async updateTask(id: string, updates: Partial<Omit<Task, 'id'>>): Promise<Task> {
+		const task = this.tasks.get(id);
+		if (!task) {
+			throw new Error(`Task not found: ${id}`);
+		}
+		Object.assign(task, updates);
+		return { ...task };
+	}
+
+	async listTasks(filters?: { status?: TaskStatus }): Promise<Task[]> {
+		let tasks = Array.from(this.tasks.values());
+		if (filters?.status) {
+			tasks = tasks.filter(t => t.status === filters.status);
+		}
+		return tasks.map(t => ({ ...t }));
+	}
+
+	async addDependency(childId: string, parentId: string): Promise<void> {
+		const child = this.tasks.get(childId);
+		if (!child) {
+			throw new Error(`Task not found: ${childId}`);
+		}
+		if (!this.tasks.has(parentId)) {
+			throw new Error(`Task not found: ${parentId}`);
+		}
+		if (!child.dependencies) {
+			child.dependencies = [];
+		}
+		child.dependencies.push(parentId);
+	}
+}

--- a/src/taskBackend.ts
+++ b/src/taskBackend.ts
@@ -1,5 +1,3 @@
-import * as vscode from 'vscode';
-
 /**
  * Task status values (Misetay workflow statuses)
  */
@@ -17,9 +15,22 @@ export interface Task {
 }
 
 /**
+ * Metadata about the active backend
+ */
+export interface BackendInfo {
+	name: string;
+	persistsToFiles: boolean;
+}
+
+/**
  * Interface that task backends must implement
  */
 export interface TaskBackend {
+	/**
+	 * Return metadata about this backend
+	 */
+	backendInfo(): BackendInfo;
+
 	/**
 	 * Create a new task
 	 */

--- a/src/taskStatusView.ts
+++ b/src/taskStatusView.ts
@@ -8,12 +8,12 @@ import { TaskBackend, Task } from './taskBackend';
  */
 export class TaskStatusView {
 	private panel: vscode.WebviewPanel | undefined;
-	private backend: TaskBackend;
+	private getBackend: () => TaskBackend;
 	private disposables: vscode.Disposable[] = [];
 	private taskCardTemplate: string;
 
-	constructor(private context: vscode.ExtensionContext, backend: TaskBackend) {
-		this.backend = backend;
+	constructor(private context: vscode.ExtensionContext, getBackend: () => TaskBackend) {
+		this.getBackend = getBackend;
 		
 		// Load task card template
 		const templatePath = path.join(this.context.extensionPath, 'webview', 'taskCard.html');
@@ -66,7 +66,7 @@ export class TaskStatusView {
 			return;
 		}
 
-		const tasks = await this.backend.listTasks();
+		const tasks = await this.getBackend().listTasks();
 		const html = this.getWebviewContent(tasks);
 		this.panel.webview.html = html;
 	}

--- a/src/test/beadsBackend.test.ts
+++ b/src/test/beadsBackend.test.ts
@@ -41,6 +41,12 @@ suite('Beads Backend Integration Tests', () => {
 		}
 	});
 
+	test('backendInfo returns correct metadata', () => {
+		const info = backend.backendInfo();
+		assert.strictEqual(info.name, 'beads');
+		assert.strictEqual(info.persistsToFiles, true);
+	});
+
 	test('createTask creates task with correct fields', async () => {
 		const task = await backend.createTask('Test Task', 'Test description', 'ready');
 		

--- a/src/test/inMemoryBackend.test.ts
+++ b/src/test/inMemoryBackend.test.ts
@@ -1,0 +1,129 @@
+import * as assert from 'assert';
+import { InMemoryBackend } from '../inMemoryBackend';
+
+suite('InMemoryBackend Tests', () => {
+	let backend: InMemoryBackend;
+
+	setup(() => {
+		backend = new InMemoryBackend();
+	});
+
+	test('backendInfo returns correct metadata', () => {
+		const info = backend.backendInfo();
+		assert.strictEqual(info.name, 'inMemory');
+		assert.strictEqual(info.persistsToFiles, false);
+	});
+
+	test('createTask returns task with mem-N ID', async () => {
+		const task = await backend.createTask('Test Task', 'Test description', 'ready');
+
+		assert.strictEqual(task.id, 'mem-1');
+		assert.strictEqual(task.title, 'Test Task');
+		assert.strictEqual(task.description, 'Test description');
+		assert.strictEqual(task.status, 'ready');
+	});
+
+	test('createTask assigns sequential IDs', async () => {
+		const t1 = await backend.createTask('Task 1', 'Desc 1');
+		const t2 = await backend.createTask('Task 2', 'Desc 2');
+		const t3 = await backend.createTask('Task 3', 'Desc 3');
+
+		assert.strictEqual(t1.id, 'mem-1');
+		assert.strictEqual(t2.id, 'mem-2');
+		assert.strictEqual(t3.id, 'mem-3');
+	});
+
+	test('createTask defaults to ready status', async () => {
+		const task = await backend.createTask('Default Status', 'Description');
+		assert.strictEqual(task.status, 'ready');
+	});
+
+	test('updateTask updates fields', async () => {
+		const task = await backend.createTask('Original', 'Desc', 'ready');
+		const updated = await backend.updateTask(task.id, { title: 'Updated', status: 'in_progress' });
+
+		assert.strictEqual(updated.title, 'Updated');
+		assert.strictEqual(updated.status, 'in_progress');
+		assert.strictEqual(updated.description, 'Desc');
+	});
+
+	test('updateTask throws for nonexistent task', async () => {
+		await assert.rejects(
+			() => backend.updateTask('mem-999', { title: 'Nope' }),
+			/Task not found: mem-999/
+		);
+	});
+
+	test('listTasks returns all tasks', async () => {
+		await backend.createTask('Task 1', 'Desc 1', 'ready');
+		await backend.createTask('Task 2', 'Desc 2', 'in_progress');
+
+		const tasks = await backend.listTasks();
+		assert.strictEqual(tasks.length, 2);
+	});
+
+	test('listTasks filters by status', async () => {
+		await backend.createTask('Task 1', 'Desc 1', 'ready');
+		await backend.createTask('Task 2', 'Desc 2', 'in_progress');
+		await backend.createTask('Task 3', 'Desc 3', 'ready');
+
+		const tasks = await backend.listTasks({ status: 'ready' });
+		assert.strictEqual(tasks.length, 2);
+		assert.ok(tasks.every(t => t.status === 'ready'));
+	});
+
+	test('listTasks returns empty array when no tasks', async () => {
+		const tasks = await backend.listTasks();
+		assert.strictEqual(tasks.length, 0);
+	});
+
+	test('addDependency records dependency', async () => {
+		const parent = await backend.createTask('Parent', 'Desc', 'ready');
+		const child = await backend.createTask('Child', 'Desc', 'ready');
+
+		await backend.addDependency(child.id, parent.id);
+
+		const tasks = await backend.listTasks();
+		const childTask = tasks.find(t => t.id === child.id);
+		assert.ok(childTask?.dependencies?.includes(parent.id));
+	});
+
+	test('addDependency supports multiple dependencies', async () => {
+		const p1 = await backend.createTask('Parent 1', 'Desc', 'ready');
+		const p2 = await backend.createTask('Parent 2', 'Desc', 'ready');
+		const child = await backend.createTask('Child', 'Desc', 'ready');
+
+		await backend.addDependency(child.id, p1.id);
+		await backend.addDependency(child.id, p2.id);
+
+		const tasks = await backend.listTasks();
+		const childTask = tasks.find(t => t.id === child.id);
+		assert.strictEqual(childTask?.dependencies?.length, 2);
+		assert.ok(childTask?.dependencies?.includes(p1.id));
+		assert.ok(childTask?.dependencies?.includes(p2.id));
+	});
+
+	test('addDependency throws for nonexistent child', async () => {
+		const parent = await backend.createTask('Parent', 'Desc', 'ready');
+		await assert.rejects(
+			() => backend.addDependency('mem-999', parent.id),
+			/Task not found: mem-999/
+		);
+	});
+
+	test('addDependency throws for nonexistent parent', async () => {
+		const child = await backend.createTask('Child', 'Desc', 'ready');
+		await assert.rejects(
+			() => backend.addDependency(child.id, 'mem-999'),
+			/Task not found: mem-999/
+		);
+	});
+
+	test('returned tasks are copies (not references)', async () => {
+		const task = await backend.createTask('Test', 'Desc', 'ready');
+		task.title = 'Mutated';
+
+		const tasks = await backend.listTasks();
+		assert.strictEqual(tasks[0].title, 'Test');
+	});
+});


### PR DESCRIPTION
Adds InMemoryBackend as a zero-dependency alternative to Beads CLI, letting users try the full plan/execute/review workflow without installing external tools. Backend is selectable via the misetay.taskBackend setting and hot-swaps without requiring reload.

- Add BackendInfo type and backendInfo() to TaskBackend interface
- Implement InMemoryBackend with Map store, mem-N IDs, and full test suite
- Add misetay.taskBackend configuration setting (beads/inMemory)
- Register misetay_backendInfo language model tool
- Refactor tools and views to use () => TaskBackend getters for hot-swap
- Update planning and execution skills for conditional commit logic
- Include OpenSpec change artifacts (proposal, design, specs, tasks)