### PR TITLE
Bundle @beads/bd in the extension package

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ Sadly, we don't have this yet. But perhaps in the near future?
 
 - **GitHub Copilot**: Provides the AI agent and code generation capabilities
 
-### Required Tools
+### Task Backend
 
-- **Task Backend** (default: [Beads](https://beads.dev))
-  - Install Beads CLI: `brew install beads` (or via npm/go)
-  - Alternative backends: Linear, GitHub Issues, JIRA, etc.
+The default task backend is [Beads](https://github.com/steveyegge/beads), which is bundled with the extension. No separate installation is needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
-  "name": "smidja",
+  "name": "misetay",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "smidja",
+      "name": "misetay",
       "version": "0.1.0",
+      "dependencies": {
+        "@beads/bd": "^0.49.4"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
@@ -30,6 +33,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@beads/bd": {
+      "version": "0.49.4",
+      "resolved": "https://registry.npmjs.org/@beads/bd/-/bd-0.49.4.tgz",
+      "integrity": "sha512-cnK6LibJGHqkniKDUB8laFdO2Ajj0V3KBrYbUD8XI48K2Cb4i/ioElb0uNt+YO+sbWKSk/Xajaodi8A7eHiBpw==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "android"
+      ],
+      "bin": {
+        "bd": "bin/bd.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -260,6 +260,9 @@
     "test:integ": "vscode-test",
     "test": "npm run compile && mocha out/test/beadsBackend.test.js --timeout 10000 --ui tdd"
   },
+  "dependencies": {
+    "@beads/bd": "^0.49.4"
+  },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",


### PR DESCRIPTION
Users no longer need to install the Beads CLI separately. The extension resolves the bundled binary from node_modules, falling back to system PATH if the package isn't present.