### PR TITLE
Declare clearHighlights tool and clean up highlighter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/package.json
+++ b/package.json
@@ -248,6 +248,18 @@
           "type": "object",
           "properties": {}
         }
+      },
+      {
+        "name": "misetay_clearHighlights",
+        "displayName": "Clear Highlights",
+        "toolReferenceName": "clearHighlights",
+        "modelDescription": "Clears any line highlights previously applied by highlightLines. Call this after code review to remove visual decorations.",
+        "userDescription": "Clear line highlights in the active editor",
+        "canBeReferencedInPrompt": true,
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
       }
     ]
   },

--- a/src/highlighter.ts
+++ b/src/highlighter.ts
@@ -3,17 +3,6 @@ import * as vscode from "vscode";
 export class Highlighter {
     private highlightDecoration: vscode.TextEditorDecorationType | undefined;
 
-    private clampLine(line: number, document: vscode.TextDocument): number {
-        const maxLine = document.lineCount;
-        if (line < 1) {
-            return 1;
-        }
-        if (line > maxLine) {
-            return maxLine;
-        }
-        return line;
-    }
-
     clearHighlights() {
         if (this.highlightDecoration) {
             this.highlightDecoration.dispose();


### PR DESCRIPTION
Add missing misetay_clearHighlights tool declaration to package.json and remove unused clampLine method from Highlighter class.