### PR TITLE
Add initTaskSystem tool so agent can initialize beads without shelling out

### DIFF
--- a/agents/Misatay.agent.md
+++ b/agents/Misatay.agent.md
@@ -9,6 +9,7 @@ tools:
   - dshearer.misatay/openFile
   - dshearer.misatay/highlightLines
   - dshearer.misatay/navigateToLine
+  - dshearer.misatay/initTaskSystem
   - dshearer.misatay/createTask
   - dshearer.misatay/updateTask
   - dshearer.misatay/listTasks
@@ -89,14 +90,15 @@ Use the **Needs Help Skill** when tasks are stuck:
 
 When you first engage with a user:
 
-1. Use `dshearer.misatay/listTasks` to check for existing tasks
-2. Determine which phase is needed:
+1. Use `dshearer.misatay/initTaskSystem` to ensure the task system is initialized
+2. Use `dshearer.misatay/listTasks` to check for existing tasks
+3. Determine which phase is needed:
    - **No tasks or new feature?** → Use Planning Skill
    - **User says to start working, begin implementation, continue, or work on tasks?** → Use Execution Skill
    - **Tasks exist with ready/in-progress status?** → Use Execution Skill
    - **User asks to review committed tasks?** → Use Review Skill
    - **Tasks have `needs_help` status?** → Use Needs Help Skill
    - **User asks "what do I need to do?"** → Use Needs Help Skill (surfaces both `needs_help` and `committed` tasks)
-3. Load the appropriate skill and follow its guidance
+4. Load the appropriate skill and follow its guidance
 
 The skills contain detailed instructions for each phase. Don't duplicate their logic here - defer to them.

--- a/package.json
+++ b/package.json
@@ -244,6 +244,18 @@
         }
       },
       {
+        "name": "misatay_initTaskSystem",
+        "displayName": "Initialize Task System",
+        "toolReferenceName": "initTaskSystem",
+        "modelDescription": "Initializes the task system for the current workspace. For the Beads backend, this runs 'bd init' to create the .beads/ directory. Call this before creating tasks if the task system has not been set up yet. Safe to call if already initialized.",
+        "userDescription": "Initialize the task system in the current workspace",
+        "canBeReferencedInPrompt": true,
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
         "name": "misatay_backendInfo",
         "displayName": "Backend Info",
         "toolReferenceName": "backendInfo",

--- a/skills/planning/SKILL.md
+++ b/skills/planning/SKILL.md
@@ -78,6 +78,8 @@ Does this breakdown make sense? Any tasks to add, remove, or split?
 
 Once the user approves, create tasks using the tools:
 
+**First**, call `dshearer.misatay/initTaskSystem` to ensure the task system is initialized in the workspace. This is safe to call even if already initialized.
+
 **For each task in the approved breakdown:**
 
 1. **Create the task** using `dshearer.misatay/createTask`:

--- a/src/beadsBackend.ts
+++ b/src/beadsBackend.ts
@@ -41,6 +41,21 @@ export class BeadsBackend implements TaskBackend {
 		return { name: 'beads', persistsToFiles: true };
 	}
 
+	async init(): Promise<string> {
+		try {
+			const { stdout } = await execFileAsync(bdPath, ['init'], {
+				cwd: this.workspaceRoot
+			});
+			return stdout.trim() || 'Beads initialized successfully.';
+		} catch (error: any) {
+			// bd init may fail if already initialized - that's ok
+			if (error.message?.includes('already initialized')) {
+				return 'Beads is already initialized in this workspace.';
+			}
+			throw new Error(`Failed to initialize Beads: ${error.message}`);
+		}
+	}
+
 	/**
 	 * Map Misatay status to Beads status and labels
 	 */

--- a/src/inMemoryBackend.ts
+++ b/src/inMemoryBackend.ts
@@ -12,6 +12,10 @@ export class InMemoryBackend implements TaskBackend {
 		return { name: 'inMemory', persistsToFiles: false };
 	}
 
+	async init(): Promise<string> {
+		return 'In-memory backend is ready (no initialization needed).';
+	}
+
 	async createTask(title: string, description: string, status: TaskStatus = 'ready'): Promise<Task> {
 		const id = `mem-${this.nextId++}`;
 		const task: Task = { id, title, description, status };

--- a/src/taskBackend.ts
+++ b/src/taskBackend.ts
@@ -32,6 +32,13 @@ export interface TaskBackend {
 	backendInfo(): BackendInfo;
 
 	/**
+	 * Initialize the task backend for the current workspace.
+	 * For backends that persist to files, this creates the necessary
+	 * directory structure. No-op if already initialized.
+	 */
+	init(): Promise<string>;
+
+	/**
 	 * Create a new task
 	 */
 	createTask(title: string, description: string, status?: TaskStatus): Promise<Task>;

--- a/src/taskTools.ts
+++ b/src/taskTools.ts
@@ -114,6 +114,28 @@ export function registerTaskTools(context: vscode.ExtensionContext, getBackend: 
 		}
 	});
 
+	// Register initTaskSystem tool
+	const initTaskSystemTool = vscode.lm.registerTool('misatay_initTaskSystem', {
+		async invoke(options, token) {
+			try {
+				const result = await getBackend().init();
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart(result)
+				]);
+			} catch (error: any) {
+				return new vscode.LanguageModelToolResult([
+					new vscode.LanguageModelTextPart(`Error initializing task system: ${error.message}`)
+				]);
+			}
+		},
+
+		prepareInvocation(options, token) {
+			return {
+				invocationMessage: 'Initializing task system'
+			};
+		}
+	});
+
 	// Register backendInfo tool
 	const backendInfoTool = vscode.lm.registerTool('misatay_backendInfo', {
 		async invoke(options, token) {
@@ -130,8 +152,8 @@ export function registerTaskTools(context: vscode.ExtensionContext, getBackend: 
 		}
 	});
 
-	context.subscriptions.push(createTaskTool, updateTaskTool, listTasksTool, addDependencyTool, backendInfoTool);
-	console.log('Misatay: Registered 5 task management tools');
+	context.subscriptions.push(createTaskTool, updateTaskTool, listTasksTool, addDependencyTool, initTaskSystemTool, backendInfoTool);
+	console.log('Misatay: Registered 6 task management tools');
 	
 	// List all available tools to verify registration
 	setTimeout(() => {


### PR DESCRIPTION
The agent was trying to run bd init via the terminal, but bd is not on PATH - it is bundled inside the extension node_modules. This adds a dedicated LM tool that uses the same bundled binary as all other task operations.