### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/dshearer/misatay/security/code-scanning/1](https://github.com/dshearer/misatay/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block either at the root of the workflow (to affect all jobs) or within the specific job, granting only the scopes actually required. For a simple CI test job that checks out code and runs Node-based build/test commands without interacting with GitHub APIs for writes, `contents: read` is typically sufficient.

The best minimal fix here is to add a `permissions` block under the `test` job in `.github/workflows/test.yml`, specifying `contents: read`. This keeps the change localized to the flagged job, avoids altering other workflows, and adheres to least privilege while preserving existing behavior. Concretely, edit the `test` job definition (around line 10–12) to insert:

```yaml
    permissions:
      contents: read
```

between `runs-on: ubuntu-latest` and `steps:`. No additional imports, methods, or external libraries are needed, since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
